### PR TITLE
:sparkles: feat: 피드 게시판 스켈레톤 로더 추가

### DIFF
--- a/app/(site)/feed/components/Feed.tsx
+++ b/app/(site)/feed/components/Feed.tsx
@@ -7,6 +7,7 @@ import FeedPost from "./FeedPost";
 import {usePostStore} from "@/app/store/PostStore";
 import PendingPostComponent from "./PendingPost";
 import {useAuth} from "@/app/hooks/useAuth";
+import FeedSkeleton from "./FeedSkeleton";
 
 export default function Feed() {
     const [posts, setPosts] = useState<FeedPostType[]>([]);
@@ -86,8 +87,15 @@ export default function Feed() {
 
     if (loading && posts.length === 0) {
         return (
-            <div className="flex justify-center items-center min-h-64">
-                <div className="animate-spin rounded-full h-8 w-8 border-2 border-gray-300 border-t-blue-600"></div>
+            <div className="max-w-md mx-auto">
+                {/* 필터 버튼 스켈레톤 */}
+                <div className="px-4 mb-4">
+                    <div className="flex gap-2">
+                        <div className="w-24 h-8 bg-gray-300 rounded-full animate-pulse"></div>
+                        <div className="w-20 h-8 bg-gray-300 rounded-full animate-pulse"></div>
+                    </div>
+                </div>
+                <FeedSkeleton count={3}/>
             </div>
         );
     }
@@ -163,14 +171,18 @@ export default function Feed() {
                         />
                     ))}
 
-                    {hasMore && (
+                    {/* 더 보기 로딩 시 스켈레톤 표시 */}
+                    {loading && posts.length > 0 && (
+                        <FeedSkeleton count={2}/>
+                    )}
+
+                    {hasMore && !loading && (
                         <div className="text-center py-4">
                             <button
                                 onClick={handleLoadMore}
-                                disabled={loading}
-                                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 transition-colors"
+                                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
                             >
-                                {loading ? "로딩 중..." : "더 보기"}
+                                더 보기
                             </button>
                         </div>
                     )}

--- a/app/(site)/feed/components/FeedPostSkeleton.tsx
+++ b/app/(site)/feed/components/FeedPostSkeleton.tsx
@@ -1,0 +1,50 @@
+export default function FeedPostSkeleton() {
+    return (
+        <article className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm mb-6 animate-pulse">
+            {/* 헤더 스켈레톤 */}
+            <div className="flex items-center justify-between p-4">
+                <div className="flex items-center gap-3">
+                    {/* 프로필 이미지 스켈레톤 */}
+                    <div className="w-8 h-8 bg-gray-300 rounded-full"></div>
+                    <div>
+                        {/* 사용자명 스켈레톤 */}
+                        <div className="h-4 bg-gray-300 rounded w-20 mb-1"></div>
+                        {/* 시간 스켈레톤 */}
+                        <div className="h-3 bg-gray-300 rounded w-16"></div>
+                    </div>
+                </div>
+                {/* 더보기 버튼 스켈레톤 */}
+                <div className="w-5 h-5 bg-gray-300 rounded"></div>
+            </div>
+
+            {/* 이미지 스켈레톤 */}
+            <div className="w-full h-64 bg-gray-300"></div>
+
+            {/* 액션 버튼들 스켈레톤 */}
+            <div className="p-4">
+                <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-4">
+                        {/* 좋아요, 댓글, 공유 버튼 */}
+                        <div className="w-6 h-6 bg-gray-300 rounded"></div>
+                        <div className="w-6 h-6 bg-gray-300 rounded"></div>
+                        <div className="w-6 h-6 bg-gray-300 rounded"></div>
+                    </div>
+                    {/* 저장 버튼 */}
+                    <div className="w-6 h-6 bg-gray-300 rounded"></div>
+                </div>
+
+                {/* 좋아요 수 스켈레톤 */}
+                <div className="h-4 bg-gray-300 rounded w-24 mb-2"></div>
+            </div>
+
+            {/* 콘텐츠 스켈레톤 */}
+            <div className="px-4 pb-4">
+                <div className="space-y-2">
+                    <div className="h-4 bg-gray-300 rounded w-full"></div>
+                    <div className="h-4 bg-gray-300 rounded w-3/4"></div>
+                    <div className="h-4 bg-gray-300 rounded w-1/2"></div>
+                </div>
+            </div>
+        </article>
+    );
+}

--- a/app/(site)/feed/components/FeedSkeleton.tsx
+++ b/app/(site)/feed/components/FeedSkeleton.tsx
@@ -1,0 +1,15 @@
+import FeedPostSkeleton from "./FeedPostSkeleton";
+
+interface FeedSkeletonProps {
+    count?: number;
+}
+
+export default function FeedSkeleton({count = 3}: FeedSkeletonProps) {
+    return (
+        <div className="space-y-6">
+            {Array.from({length: count}, (_, index) => (
+                <FeedPostSkeleton key={index}/>
+            ))}
+        </div>
+    );
+}


### PR DESCRIPTION
                   🔧 생성된 컴포넌트들

                   1. FeedPostSkeleton.tsx - 단일 게시글 스켈레톤

                   - 프로필 이미지, 사용자명, 시간 스켈레톤
                   - 이미지 영역 스켈레톤 (고정 높이 264px)
                   - 액션 버튼들 (좋아요, 댓글, 공유, 저장) 스켈레톤
                   - 좋아요 수 및 텍스트 콘텐츠 스켈레톤
                   - animate-pulse 애니메이션 적용

                   2. FeedSkeleton.tsx - 다중 게시글 스켈레톤

                   - count prop으로 표시할 스켈레톤 개수 조정 (기본값: 3)
                   - 여러 개의 FeedPostSkeleton을 배열로 렌더링

                   3. Feed.tsx - 스켈레톤 적용

                   - 초기 로딩: 필터 버튼 스켈레톤 + 3개 게시글 스켈레톤
                   - 더 보기 로딩: 기존 게시글 아래 2개 추가 스켈레톤

                   🎨 적용된 로딩 상태

                   - 첫 로딩: 전체 UI 구조를 시뮬레이션하는 스켈레톤
                   - 페이지네이션: 기존 콘텐츠 유지하며 추가 로딩 표시
                   - 사용자 경험: 스피너 대신 실제 콘텐츠 형태로 로딩 상태 표시
